### PR TITLE
Fixed draw lag (at least as far as I can tell)

### DIFF
--- a/src/heroesgrave/paint/image/Canvas.java
+++ b/src/heroesgrave/paint/image/Canvas.java
@@ -161,6 +161,11 @@ public class Canvas
 			}
 			else if(prev instanceof Frame)
 			{
+				/*
+				 * Think about reverting this somehow:
+				 * (Causes tool preview buildup, bad on the shape drawers)
+				 */
+				
 				//temp = hist.getUpdatedImage();
 				((Frame) prev).apply(this.image); //changed this.temp to this.image
 				g.drawImage(this.image, 0, 0, null); //<-- same here

--- a/src/heroesgrave/paint/image/CanvasManager.java
+++ b/src/heroesgrave/paint/image/CanvasManager.java
@@ -248,7 +248,7 @@ public class CanvasManager
 		@Override
 		public void paint(Graphics arg0)
 		{
-			long time = System.nanoTime();
+			//long time = System.nanoTime();
 			super.paint(arg0);
 			Graphics2D g = (Graphics2D) arg0;
 			Graphics2D draw = background.createGraphics();
@@ -304,12 +304,12 @@ public class CanvasManager
 			/*
 			 * Timer for paint() method, prints the time spent in paint() averaged over 100 calls. Prints every 100 calls.
 			 */
-			avg += System.nanoTime() - time;
+			/*avg += System.nanoTime() - time;
 			if(count++ >= 100) {
 				System.out.println(avg/(1000000000*100f));
 				avg = 0;
 				count = 0;
-			}
+			}*/
 			/*
 			 * Findings:
 			 * "Healthy" paint cycle is ~0.005 sec per the 100 avg

--- a/src/heroesgrave/paint/image/History.java
+++ b/src/heroesgrave/paint/image/History.java
@@ -167,7 +167,6 @@ public class History
 			f.apply(image);
 			history.push(f);
 		}
-		System.out.println("GetUpdatedImage");
 		return image;
 	}
 }


### PR DESCRIPTION
It turns out it seemed to be the checkered canvas background. >_> ?

Uses lazy initialization and buffer copying instead of every-frame allocation and rendering for background image.
