### PR TITLE
Add a getIndex method to RawImage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,4 @@
-Spade
+Spade Fork
 =====
 
-I was annoyed at the lack of a suitable (Pinta is a glitchy nightmare, GIMP is overcomplicated and not very useful for pixel art, etc.)
-equivalent of Paint.NET for Linux, and was unable to do pixel art for my games.
-If you want something done well, you have to do it yourself it seems.
-
-I'll put up a changelog here at some point.
-
-Developing
-==========
-Note that most contributors are probably looking to develop on the editing functions rather than
-the framework of the application itself. If this includes you, head over to the
-[Core plugin repository](https://github.com/Spade-Editor/Core) and see the instructions there. You
-will still be required to set up Spade for development.
-
-1. Clone the repository (`git clone https://github.com/Spade-Editor/Spade`).
-2. Import the source into the IDE of your choice.
-3. Add `lib/weblaf-XXX.jar` to the build path of the project.
-4. Run `Start.java` (Found in `src/heroesgrave/spade/main/`). Make sure it works. If it doesn't and you can't work out why, create an issue.
-5. (Optional) You will probably want to install the `Core` plugin, which contains the majority of
-the editing functions. More information is available [here](https://github.com/Spade-Editor/Core#developing).
-6. Make whatever changes you want.
-7. Commit your changes and make a pull request.
-
-Super-Contributors
-==================
-- [Longor1996](https://github.com/Longor1996)
-- [BurntPizza](https://github.com/BurntPizza)
-
-These people have done significant amounts of work towards Spade out of their own time.
-
-Other Contributors
-==================
-- [Gef4K](https://github.com/Gef4K)
-- [markbernard](https://github.com/markbernard)
-- [pwnedary](https://github.com/pwnedary)
-
-While these people have not quite done as much as the supercontributors above, the help they have provided is still highly appreciated.
-
-**Special thanks to all people who have contributed to the project in one way or another.**
+My fork of Spade.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,41 @@
-Spade Fork
+Spade
 =====
 
-My fork of Spade.
+I was annoyed at the lack of a suitable (Pinta is a glitchy nightmare, GIMP is overcomplicated and not very useful for pixel art, etc.)
+equivalent of Paint.NET for Linux, and was unable to do pixel art for my games.
+If you want something done well, you have to do it yourself it seems.
+
+I'll put up a changelog here at some point.
+
+Developing
+==========
+Note that most contributors are probably looking to develop on the editing functions rather than
+the framework of the application itself. If this includes you, head over to the
+[Core plugin repository](https://github.com/Spade-Editor/Core) and see the instructions there. You
+will still be required to set up Spade for development.
+
+1. Clone the repository (`git clone https://github.com/Spade-Editor/Spade`).
+2. Import the source into the IDE of your choice.
+3. Add `lib/weblaf-XXX.jar` to the build path of the project.
+4. Run `Start.java` (Found in `src/heroesgrave/spade/main/`). Make sure it works. If it doesn't and you can't work out why, create an issue.
+5. (Optional) You will probably want to install the `Core` plugin, which contains the majority of
+the editing functions. More information is available [here](https://github.com/Spade-Editor/Core#developing).
+6. Make whatever changes you want.
+7. Commit your changes and make a pull request.
+
+Super-Contributors
+==================
+- [Longor1996](https://github.com/Longor1996)
+- [BurntPizza](https://github.com/BurntPizza)
+
+These people have done significant amounts of work towards Spade out of their own time.
+
+Other Contributors
+==================
+- [Gef4K](https://github.com/Gef4K)
+- [markbernard](https://github.com/markbernard)
+- [pwnedary](https://github.com/pwnedary)
+
+While these people have not quite done as much as the supercontributors above, the help they have provided is still highly appreciated.
+
+**Special thanks to all people who have contributed to the project in one way or another.**

--- a/src/heroesgrave/spade/image/RawImage.java
+++ b/src/heroesgrave/spade/image/RawImage.java
@@ -460,6 +460,17 @@ public final class RawImage
 		return y * width + x;
 	}
 	
+	/**
+	 * Get the index in the underlying array of pixel position x, y.
+	 * @param x Pixel X position
+	 * @param y Pixel Y position
+	 * @return The position in the underlying int array.
+	 */
+	public int getIndex(int x, int y)
+	{
+		return index(x, y);
+	}
+	
 	public int[] copyBuffer()
 	{
 		return Arrays.copyOf(buffer, buffer.length);

--- a/src/heroesgrave/spade/image/change/ArgumentOutOfRangeException.java
+++ b/src/heroesgrave/spade/image/change/ArgumentOutOfRangeException.java
@@ -1,0 +1,37 @@
+package heroesgrave.spade.image.change;
+
+@SuppressWarnings("serial")
+public class ArgumentOutOfRangeException extends RuntimeException
+{
+
+	public ArgumentOutOfRangeException()
+	{
+		// TODO Auto-generated constructor stub
+	}
+
+	public ArgumentOutOfRangeException(String message)
+	{
+		super(message);
+		// TODO Auto-generated constructor stub
+	}
+
+	public ArgumentOutOfRangeException(Throwable cause)
+	{
+		super(cause);
+		// TODO Auto-generated constructor stub
+	}
+
+	public ArgumentOutOfRangeException(String message, Throwable cause)
+	{
+		super(message, cause);
+		// TODO Auto-generated constructor stub
+	}
+
+	public ArgumentOutOfRangeException(String message, Throwable cause,
+			boolean enableSuppression, boolean writableStackTrace)
+	{
+		super(message, cause, enableSuppression, writableStackTrace);
+		// TODO Auto-generated constructor stub
+	}
+
+}


### PR DESCRIPTION
It's sort of necessary when writing nontrivial plugins that access the int buffer of `RawImage`s. Also there is an exception that can be thrown whenever an effect's parameter is out of bounds.

Sorry about the crufty extra commits that change the readme; Apparently github is sucky enough to not let you select what commits you want to include in a pull request. :(