### PR TITLE
Removed the hardcoded .bmp, .gif, etc stuff in favor of querying ImageIO

### DIFF
--- a/src/heroesgrave/spade/gui/GUIManager.java
+++ b/src/heroesgrave/spade/gui/GUIManager.java
@@ -31,6 +31,7 @@ import heroesgrave.spade.gui.menus.InfoMenuBar;
 import heroesgrave.spade.gui.menus.Menu;
 import heroesgrave.spade.image.Document;
 import heroesgrave.spade.io.ImageImporter;
+import heroesgrave.spade.io.ReadableFileFilter;
 import heroesgrave.spade.main.Input;
 import heroesgrave.spade.main.Spade;
 import heroesgrave.spade.main.UserPreferences;
@@ -267,17 +268,9 @@ public class GUIManager
                 try {
                     @SuppressWarnings("unchecked")
 					final File toload = (File) ((List<File>) t.getTransferData(DataFlavor.javaFileListFlavor)).get(0);
-                    String filename = toload.getName();
-                    int i = filename.indexOf(".");
-                    String extension = filename.substring(i+1);
+                    boolean supported = new ReadableFileFilter().accept(toload);
 
-                    boolean supported = 
-                    		filename.endsWith(".png") ||
-                    		filename.endsWith(".jpg") ||
-                    		filename.endsWith(".bmp") ||
-                    		ImageImporter.get(extension) != null;
-
-                    if (i > 0 && !extension.equals("") && supported)
+                    if (supported)
                     {
                         new Thread(new Runnable()
             			{

--- a/src/heroesgrave/spade/gui/menus/Menu.java
+++ b/src/heroesgrave/spade/gui/menus/Menu.java
@@ -26,6 +26,7 @@ import heroesgrave.spade.gui.misc.ClipboardHandler;
 import heroesgrave.spade.gui.misc.WeblafWrapper;
 import heroesgrave.spade.image.Document;
 import heroesgrave.spade.io.ImageImporter;
+import heroesgrave.spade.io.ReadableFileFilter;
 import heroesgrave.spade.main.Popup;
 import heroesgrave.spade.main.Spade;
 import heroesgrave.spade.plugin.PluginManager;
@@ -247,57 +248,7 @@ public class Menu
 		final WebFileChooser chooser = new WebFileChooser(Spade.getDir());
 		chooser.setFileSelectionMode(WebFileChooser.FILES_ONLY);
 		chooser.setAcceptAllFileFilterUsed(false);
-		chooser.addChoosableFileFilter(new FileFilter()
-		{
-			@Override
-			public boolean accept(File f)
-			{
-				if(f.isDirectory())
-					return false;
-				String name = f.getAbsolutePath();
-				if(name.endsWith(".png"))
-					return true;
-				if(name.endsWith(".jpg"))
-					return true;
-				if(name.endsWith(".bmp"))
-					return true;
-				return false;
-			}
-			
-			@Override
-			public String getDescription()
-			{
-				return "ImageIO supported import formats (.png, .jpg, .bmp)";
-			}
-		});
-		chooser.setFileFilter(new FileFilter()
-		{
-			@Override
-			public boolean accept(File f)
-			{
-				if(f.isDirectory())
-					return false;
-				String name = f.getAbsolutePath();
-				if(name.endsWith(".png"))
-					return true;
-				if(name.endsWith(".jpg"))
-					return true;
-				if(name.endsWith(".bmp"))
-					return true;
-				
-				int i = name.lastIndexOf('.');
-				if(i < 0)
-					return false;
-				
-				return ImageImporter.get(name.substring(i + 1)) != null;
-			}
-			
-			@Override
-			public String getDescription()
-			{
-				return "All supported import formats";
-			}
-		});
+		chooser.setFileFilter(new ReadableFileFilter());
 		
 		// Add ALL the custom image-importers!
 		ImageImporter.addAllImporters(chooser);

--- a/src/heroesgrave/spade/image/IImage.java
+++ b/src/heroesgrave/spade/image/IImage.java
@@ -1,0 +1,22 @@
+package heroesgrave.spade.image;
+
+import heroesgrave.spade.image.RawImage.MaskMode;
+
+public interface IImage 
+{
+	public void move(int dx, int dy);
+	public void drawLine(int x1, int y1, final int x2, final int y2, final int c);
+	public void drawRect(int x1, int y1, int x2, int y2, final int c);
+	public void fillRect(int x1, int y1, int x2, int y2, int c);
+	public void drawPixel(int x, int y, int c);
+	public void drawPixelChecked(int x, int y, int c);
+	public void fill(int c);
+	public void setMask(boolean[] mask);
+	public void clear(int c);
+	public void setPixel(int x, int y, int c);
+	public int getPixel(int x, int y);
+	public void fillMask(MaskMode mode);
+	public void maskRect(int x1, int y1, int x2, int y2, MaskMode mode);
+	public void setMaskEnabled(boolean enabled);
+	public void toggleMask();
+}

--- a/src/heroesgrave/spade/io/ReadableFileFilter.java
+++ b/src/heroesgrave/spade/io/ReadableFileFilter.java
@@ -1,0 +1,40 @@
+package heroesgrave.spade.io;
+
+import java.io.File;
+import java.util.Arrays;
+
+import javax.imageio.ImageIO;
+import javax.swing.filechooser.FileFilter;
+
+public class ReadableFileFilter extends FileFilter
+{
+
+	@Override
+	public boolean accept(File f)
+	{
+		String filename = f.getName();
+		int i = filename.lastIndexOf(".");
+		if (i > -1)
+		{
+    		String extension = filename.substring(i+1).toLowerCase();
+    		return (!f.isDirectory() && 
+    				((Arrays.asList(lower(ImageIO.getReaderFormatNames())).contains(extension)) || 
+    						ImageImporter.get(extension) != null));
+		} else return false;
+	}
+
+	@Override
+	public String getDescription()
+	{
+		return "All supported file formats";
+	}
+	
+	public String[] lower(String[] original)
+	{
+		String[] newArr = new String[original.length];
+		for (int i = 0; i < original.length; i++)
+			newArr[i] = original[i].toLowerCase();
+		
+		return newArr;
+	}
+}


### PR DESCRIPTION
We can just add ImageIO plugins and the program will load them now, at least I think. The same should probably be done for exporters. I don't know why IImage is in there.